### PR TITLE
Fix backprop for broadcasting + 100% test coverage

### DIFF
--- a/microtorch/tensor/backprop.py
+++ b/microtorch/tensor/backprop.py
@@ -46,8 +46,8 @@ def backward(tensor: "tensor.Tensor") -> None:
         tensor (Tensor): The tensor to perform backpropagation on.
 
     Raises:
-        Exception: If the tensor does not have requires_grad enabled.
-        Exception: If the tensor is not a scalar tensor.
+        ValueError: If the tensor does not have requires_grad enabled.
+        ValueError: If the tensor is not a scalar tensor.
 
     Notes:
         - This function assigns a topological order to each tensor in the computation
@@ -58,9 +58,9 @@ def backward(tensor: "tensor.Tensor") -> None:
         tensor in reverse topological order.
     """
     if not tensor.requires_grad:
-        raise Exception("This tensor does not have requires_grad enabled.")
+        raise ValueError("This tensor does not have requires_grad enabled.")
     if tensor._data.size != 1:
-        raise Exception("Can only do backward on scalar tensors.")
+        raise ValueError("Can only do backward on scalar tensors.")
 
     tensor.grad = np.ones(tensor._data.shape)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ exclude_lines = [
     "if TYPE_CHECKING:",
     "pass",
 ]
-fail_under = 95
+fail_under = 98
 ignore_errors = true
 omit = [
     "tests/*",

--- a/tests/tensor/test_functional.py
+++ b/tests/tensor/test_functional.py
@@ -5,7 +5,7 @@ from microtorch.tensor import functional as F, tensor
 # pyright: reportPrivateUsage=false
 
 
-def test_add():
+def test_add_with_grads():
     a = tensor.Tensor(np.array([1, 2]), requires_grad=True)
     b = tensor.Tensor(np.array([3, 4]), requires_grad=True)
     result = F.add(a, b)
@@ -22,7 +22,73 @@ def test_add():
     assert np.array_equal(b.grad, np.array([1, 1]))
 
 
-def test_sub():
+def test_add_without_grads():
+    a = tensor.Tensor(np.array([1, 2]), requires_grad=False)
+    b = tensor.Tensor(np.array([3, 4]), requires_grad=False)
+    result = F.add(a, b)
+
+    # Add a dummy differentiable tensor to be able to call backward()
+    dummy = tensor.Tensor(np.array([0, 0]), requires_grad=True)
+    F.sum(result + dummy).backward()  # do a sum to be able to call backward()
+
+    # Check the result
+    assert np.array_equal(result._data, np.array([4, 6]))
+
+    # Check the gradients
+    assert a.grad is None
+    assert b.grad is None
+
+
+def test_add_with_lhs_grad():
+    a = tensor.Tensor(np.array([1, 2]), requires_grad=True)
+    b = tensor.Tensor(np.array([3, 4]), requires_grad=False)
+    result = F.add(a, b)
+
+    F.sum(result).backward()  # do a sum to be able to call backward()
+
+    # Check the result
+    assert np.array_equal(result._data, np.array([4, 6]))
+
+    # Check the gradients
+    assert a.grad is not None
+    assert np.array_equal(a.grad, np.array([1, 1]))
+    assert b.grad is None
+
+
+def test_add_with_rhs_grad():
+    a = tensor.Tensor(np.array([1, 2]), requires_grad=False)
+    b = tensor.Tensor(np.array([3, 4]), requires_grad=True)
+    result = F.add(a, b)
+
+    F.sum(result).backward()  # do a sum to be able to call backward()
+
+    # Check the result
+    assert np.array_equal(result._data, np.array([4, 6]))
+
+    # Check the gradients
+    assert a.grad is None
+    assert b.grad is not None
+    assert np.array_equal(b.grad, np.array([1, 1]))
+
+
+def test_add_with_broadcasting():
+    a = tensor.Tensor(np.array([1, 2]), requires_grad=True)
+    b = tensor.Tensor(np.array([3]), requires_grad=True)
+    result = F.add(a, b)
+
+    F.sum(result).backward()  # do a sum to be able to call backward()
+
+    # Check the result
+    assert np.array_equal(result._data, np.array([4, 5]))
+
+    # Check the gradients
+    assert a.grad is not None
+    assert np.array_equal(a.grad, np.array([1, 1]))
+    assert b.grad is not None
+    assert np.array_equal(b.grad, np.array([2]))
+
+
+def test_sub_with_grads():
     a = tensor.Tensor(np.array([1, 2]), requires_grad=True)
     b = tensor.Tensor(np.array([3, 4]), requires_grad=True)
     result = F.sub(a, b)
@@ -39,7 +105,73 @@ def test_sub():
     assert np.array_equal(b.grad, np.array([-1, -1]))
 
 
-def test_neg():
+def test_sub_without_grads():
+    a = tensor.Tensor(np.array([1, 2]), requires_grad=False)
+    b = tensor.Tensor(np.array([3, 4]), requires_grad=False)
+    result = F.sub(a, b)
+
+    # Add a dummy differentiable tensor to be able to call backward()
+    dummy = tensor.Tensor(np.array([0, 0]), requires_grad=True)
+    F.sum(result + dummy).backward()  # do a sum to be able to call backward()
+
+    # Check the result
+    assert np.array_equal(result._data, np.array([-2, -2]))
+
+    # Check the gradients
+    assert a.grad is None
+    assert b.grad is None
+
+
+def test_sub_with_lhs_grad():
+    a = tensor.Tensor(np.array([1, 2]), requires_grad=True)
+    b = tensor.Tensor(np.array([3, 4]), requires_grad=False)
+    result = F.sub(a, b)
+
+    F.sum(result).backward()  # do a sum to be able to call backward()
+
+    # Check the result
+    assert np.array_equal(result._data, np.array([-2, -2]))
+
+    # Check the gradients
+    assert a.grad is not None
+    assert np.array_equal(a.grad, np.array([1, 1]))
+    assert b.grad is None
+
+
+def test_sub_with_rhs_grad():
+    a = tensor.Tensor(np.array([1, 2]), requires_grad=False)
+    b = tensor.Tensor(np.array([3, 4]), requires_grad=True)
+    result = F.sub(a, b)
+
+    F.sum(result).backward()  # do a sum to be able to call backward()
+
+    # Check the result
+    assert np.array_equal(result._data, np.array([-2, -2]))
+
+    # Check the gradients
+    assert a.grad is None
+    assert b.grad is not None
+    assert np.array_equal(b.grad, np.array([-1, -1]))
+
+
+def test_sub_with_broadcasting():
+    a = tensor.Tensor(np.array([1, 2]), requires_grad=True)
+    b = tensor.Tensor(np.array([3]), requires_grad=True)
+    result = F.sub(a, b)
+
+    F.sum(result).backward()  # do a sum to be able to call backward()
+
+    # Check the result
+    assert np.array_equal(result._data, np.array([-2, -1]))
+
+    # Check the gradients
+    assert a.grad is not None
+    assert np.array_equal(a.grad, np.array([1, 1]))
+    assert b.grad is not None
+    assert np.array_equal(b.grad, np.array([-2]))
+
+
+def test_neg_with_grads():
     a = tensor.Tensor(np.array([1, 2]), requires_grad=True)
     result = F.neg(a)
 
@@ -53,7 +185,22 @@ def test_neg():
     assert np.array_equal(a.grad, np.array([-1, -1]))
 
 
-def test_mul():
+def test_neg_without_grads():
+    a = tensor.Tensor(np.array([1, 2]), requires_grad=False)
+    result = F.neg(a)
+
+    # Add a dummy differentiable tensor to be able to call backward()
+    dummy = tensor.Tensor(np.array([0, 0]), requires_grad=True)
+    F.sum(result + dummy).backward()  # do a sum to be able to call backward()
+
+    # Check the result
+    assert np.array_equal(result._data, np.array([-1, -2]))
+
+    # Check the gradients
+    assert a.grad is None
+
+
+def test_mul_with_grads():
     a = tensor.Tensor(np.array([1, 2]), requires_grad=True)
     b = tensor.Tensor(np.array([3, 4]), requires_grad=True)
     result = F.mul(a, b)
@@ -70,7 +217,73 @@ def test_mul():
     assert np.array_equal(b.grad, np.array([1, 2]))
 
 
-def test_matmul():
+def test_mul_without_grads():
+    a = tensor.Tensor(np.array([1, 2]), requires_grad=False)
+    b = tensor.Tensor(np.array([3, 4]), requires_grad=False)
+    result = F.mul(a, b)
+
+    # Add a dummy differentiable tensor to be able to call backward()
+    dummy = tensor.Tensor(np.array([0, 0]), requires_grad=True)
+    F.sum(result + dummy).backward()  # do a sum to be able to call backward()
+
+    # Check the result
+    assert np.array_equal(result._data, np.array([3, 8]))
+
+    # Check the gradients
+    assert a.grad is None
+    assert b.grad is None
+
+
+def test_mul_with_lhs_grad():
+    a = tensor.Tensor(np.array([1, 2]), requires_grad=True)
+    b = tensor.Tensor(np.array([3, 4]), requires_grad=False)
+    result = F.mul(a, b)
+
+    F.sum(result).backward()  # do a sum to be able to call backward()
+
+    # Check the result
+    assert np.array_equal(result._data, np.array([3, 8]))
+
+    # Check the gradients
+    assert a.grad is not None
+    assert np.array_equal(a.grad, np.array([3, 4]))
+    assert b.grad is None
+
+
+def test_mul_with_rhs_grad():
+    a = tensor.Tensor(np.array([1, 2]), requires_grad=False)
+    b = tensor.Tensor(np.array([3, 4]), requires_grad=True)
+    result = F.mul(a, b)
+
+    F.sum(result).backward()  # do a sum to be able to call backward()
+
+    # Check the result
+    assert np.array_equal(result._data, np.array([3, 8]))
+
+    # Check the gradients
+    assert a.grad is None
+    assert b.grad is not None
+    assert np.array_equal(b.grad, np.array([1, 2]))
+
+
+def test_mul_with_broadcasting():
+    a = tensor.Tensor(np.array([1, 3]), requires_grad=True)
+    b = tensor.Tensor(np.array([7]), requires_grad=True)
+    result = F.mul(a, b)
+
+    F.sum(result).backward()  # do a sum to be able to call backward()
+
+    # Check the result
+    assert np.array_equal(result._data, np.array([1 * 7, 3 * 7]))
+
+    # Check the gradients
+    assert a.grad is not None
+    assert np.array_equal(a.grad, np.array([7, 7]))
+    assert b.grad is not None
+    assert np.array_equal(b.grad, np.array([1 + 3]))
+
+
+def test_matmul_with_grads():
     a = tensor.Tensor(np.array([[1, 3], [3, 10]]), requires_grad=True)
     b = tensor.Tensor(np.array([[5, -2], [10, 20]]), requires_grad=True)
     result = F.matmul(a, b)
@@ -87,7 +300,56 @@ def test_matmul():
     assert np.array_equal(b.grad, np.array([[4, 4], [13, 13]]))
 
 
-def test_div():
+def test_matmul_without_grads():
+    a = tensor.Tensor(np.array([[1, 3], [3, 10]]), requires_grad=False)
+    b = tensor.Tensor(np.array([[5, -2], [10, 20]]), requires_grad=False)
+    result = F.matmul(a, b)
+
+    # Add a dummy differentiable tensor to be able to call backward()
+    dummy = tensor.Tensor(np.array([0, 0]), requires_grad=True)
+    F.sum(result + dummy).backward()  # do a sum to be able to call backward()
+
+    # Check the result
+    assert np.array_equal(result._data, np.array([[35, 58], [115, 194]]))
+
+    # Check the gradients
+    assert a.grad is None
+    assert b.grad is None
+
+
+def test_matmul_with_lhs_grad():
+    a = tensor.Tensor(np.array([[1, 3], [3, 10]]), requires_grad=True)
+    b = tensor.Tensor(np.array([[5, -2], [10, 20]]), requires_grad=False)
+    result = F.matmul(a, b)
+
+    F.sum(result).backward()  # do a sum to be able to call backward()
+
+    # Check the result
+    assert np.array_equal(result._data, np.array([[35, 58], [115, 194]]))
+
+    # Check the gradients
+    assert a.grad is not None
+    assert np.array_equal(a.grad, np.array([[3, 30], [3, 30]]))
+    assert b.grad is None
+
+
+def test_matmul_with_rhs_grad():
+    a = tensor.Tensor(np.array([[1, 3], [3, 10]]), requires_grad=False)
+    b = tensor.Tensor(np.array([[5, -2], [10, 20]]), requires_grad=True)
+    result = F.matmul(a, b)
+
+    F.sum(result).backward()  # do a sum to be able to call backward()
+
+    # Check the result
+    assert np.array_equal(result._data, np.array([[35, 58], [115, 194]]))
+
+    # Check the gradients
+    assert a.grad is None
+    assert b.grad is not None
+    assert np.array_equal(b.grad, np.array([[4, 4], [13, 13]]))
+
+
+def test_div_with_grads():
     a = tensor.Tensor(np.array([1, 2]), requires_grad=True)
     b = tensor.Tensor(np.array([3, 4]), requires_grad=True)
     result = F.div(a, b)
@@ -104,7 +366,73 @@ def test_div():
     assert np.array_equal(b.grad, np.array([-1 / 9, -1 / 8]))
 
 
-def test_sin():
+def test_div_without_grads():
+    a = tensor.Tensor(np.array([1, 2]), requires_grad=False)
+    b = tensor.Tensor(np.array([3, 4]), requires_grad=False)
+    result = F.div(a, b)
+
+    # Add a dummy differentiable tensor to be able to call backward()
+    dummy = tensor.Tensor(np.array([0, 0]), requires_grad=True)
+    F.sum(result + dummy).backward()  # do a sum to be able to call backward()
+
+    # Check the result
+    assert np.array_equal(result._data, np.array([1 / 3, 2 / 4]))
+
+    # Check the gradients
+    assert a.grad is None
+    assert b.grad is None
+
+
+def test_div_with_lhs_grad():
+    a = tensor.Tensor(np.array([1, 2]), requires_grad=True)
+    b = tensor.Tensor(np.array([3, 4]), requires_grad=False)
+    result = F.div(a, b)
+
+    F.sum(result).backward()  # do a sum to be able to call backward()
+
+    # Check the result
+    assert np.array_equal(result._data, np.array([1 / 3, 2 / 4]))
+
+    # Check the gradients
+    assert a.grad is not None
+    assert np.array_equal(a.grad, np.array([1 / 3, 1 / 4]))
+    assert b.grad is None
+
+
+def test_div_with_rhs_grad():
+    a = tensor.Tensor(np.array([1, 2]), requires_grad=False)
+    b = tensor.Tensor(np.array([3, 4]), requires_grad=True)
+    result = F.div(a, b)
+
+    F.sum(result).backward()  # do a sum to be able to call backward()
+
+    # Check the result
+    assert np.array_equal(result._data, np.array([1 / 3, 2 / 4]))
+
+    # Check the gradients
+    assert a.grad is None
+    assert b.grad is not None
+    assert np.array_equal(b.grad, np.array([-1 / 9, -1 / 8]))
+
+
+def test_div_with_broadcasting():
+    a = tensor.Tensor(np.array([1, 3]), requires_grad=True)
+    b = tensor.Tensor(np.array([7]), requires_grad=True)
+    result = F.div(a, b)
+
+    F.sum(result).backward()  # do a sum to be able to call backward()
+
+    # Check the result
+    assert np.array_equal(result._data, np.array([1 / 7, 3 / 7]))
+
+    # Check the gradients
+    assert a.grad is not None
+    assert np.array_equal(a.grad, np.array([1 / 7, 1 / 7]))
+    assert b.grad is not None
+    assert np.array_equal(b.grad, np.array([-1 / 49 - 3 / 49]))
+
+
+def test_sin_with_grads():
     a = tensor.Tensor(np.array([0, np.pi / 2]), requires_grad=True)
     result = F.sin(a)
 
@@ -118,7 +446,22 @@ def test_sin():
     assert np.allclose(a.grad, np.array([1, 0]))
 
 
-def test_cos():
+def test_sin_without_grads():
+    a = tensor.Tensor(np.array([0, np.pi / 2]), requires_grad=False)
+    result = F.sin(a)
+
+    # Add a dummy differentiable tensor to be able to call backward()
+    dummy = tensor.Tensor(np.array([0, 0]), requires_grad=True)
+    F.sum(result + dummy).backward()  # do a sum to be able to call backward()
+
+    # Check the result
+    assert np.array_equal(result._data, np.array([0, 1]))
+
+    # Check the gradients
+    assert a.grad is None
+
+
+def test_cos_with_grads():
     a = tensor.Tensor(np.array([0, np.pi / 2]), requires_grad=True)
     result = F.cos(a)
 
@@ -132,7 +475,22 @@ def test_cos():
     assert np.allclose(a.grad, np.array([0, -1]))
 
 
-def test_exp():
+def test_cos_without_grads():
+    a = tensor.Tensor(np.array([0, np.pi / 2]), requires_grad=False)
+    result = F.cos(a)
+
+    # Add a dummy differentiable tensor to be able to call backward()
+    dummy = tensor.Tensor(np.array([0, 0]), requires_grad=True)
+    F.sum(result + dummy).backward()  # do a sum to be able to call backward()
+
+    # Check the result
+    np.testing.assert_almost_equal(result._data, np.array([1, 0]))
+
+    # Check the gradients
+    assert a.grad is None
+
+
+def test_exp_with_grads():
     a = tensor.Tensor(np.array([0, 1]), requires_grad=True)
     result = F.exp(a)
 
@@ -146,7 +504,22 @@ def test_exp():
     assert np.allclose(a.grad, np.array([1, np.exp(1)]))
 
 
-def test_sum():
+def test_exp_without_grads():
+    a = tensor.Tensor(np.array([0, 1]), requires_grad=False)
+    result = F.exp(a)
+
+    # Add a dummy differentiable tensor to be able to call backward()
+    dummy = tensor.Tensor(np.array([0, 0]), requires_grad=True)
+    F.sum(result + dummy).backward()  # do a sum to be able to call backward()
+
+    # Check the result
+    np.testing.assert_almost_equal(result._data, np.array([1, np.exp(1)]))
+
+    # Check the gradients
+    assert a.grad is None
+
+
+def test_sum_with_grads():
     a = tensor.Tensor(np.array([1, 2, 3, 4]), requires_grad=True)
     result = F.sum(a)
 
@@ -160,7 +533,22 @@ def test_sum():
     assert np.array_equal(a.grad, np.array([1, 1, 1, 1]))
 
 
-def test_max():
+def test_sum_without_grads():
+    a = tensor.Tensor(np.array([1, 2, 3, 4]), requires_grad=False)
+    result = F.sum(a)
+
+    # Add a dummy differentiable tensor to be able to call backward()
+    dummy = tensor.Tensor(np.array([0]), requires_grad=True)
+    (result + dummy).backward()
+
+    # Check the result
+    assert result._data == 10
+
+    # Check the gradients
+    assert a.grad is None
+
+
+def test_max_with_grads():
     a = tensor.Tensor(np.array([1, 2, 3, 4]), requires_grad=True)
     result = F.max(a)
 
@@ -174,7 +562,22 @@ def test_max():
     assert np.array_equal(a.grad, np.array([0, 0, 0, 1]))
 
 
-def test_relu():
+def test_max_without_grads():
+    a = tensor.Tensor(np.array([1, 2, 3, 4]), requires_grad=False)
+    result = F.max(a)
+
+    # Add a dummy differentiable tensor to be able to call backward()
+    dummy = tensor.Tensor(np.array([0]), requires_grad=True)
+    (result + dummy).backward()
+
+    # Check the result
+    assert result._data == 4
+
+    # Check the gradients
+    assert a.grad is None
+
+
+def test_relu_with_grads():
     a = tensor.Tensor(np.array([-1, 2, 3, -4]), requires_grad=True)
     result = F.relu(a)
 
@@ -186,6 +589,21 @@ def test_relu():
     # Check the gradients
     assert a.grad is not None
     assert np.array_equal(a.grad, np.array([0, 1, 1, 0]))
+
+
+def test_relu_without_grads():
+    a = tensor.Tensor(np.array([-1, 2, 3, -4]), requires_grad=False)
+    result = F.relu(a)
+
+    # Add a dummy differentiable tensor to be able to call backward()
+    dummy = tensor.Tensor(np.array([0, 0, 0, 0]), requires_grad=True)
+    F.sum(result + dummy).backward()
+
+    # Check the result
+    assert np.array_equal(result._data, np.array([0, 2, 3, 0]))
+
+    # Check the gradients
+    assert a.grad is None
 
 
 def test_reshape():


### PR DESCRIPTION
Fixed the bug that used to happen during backpropagation if an operation, like addition, multiplication, etc., required broadcasting to be fulfilled. In such cases, when we do the backward phase, we need to make sure to accumulate gradients from all dimensions where broadcasting happened.

I also increased test coverage to 100%, and set the test threshold to 99% to ensure that new code is covered by tests.