### PR TITLE
Support adding parameters to a module

### DIFF
--- a/microtorch/nn/__init__.py
+++ b/microtorch/nn/__init__.py
@@ -1,10 +1,12 @@
 from .modules.activation import ReLU, Softmax
 from .modules.linear import Linear
 from .modules.module import Module
+from .modules.parameter import Parameter
 
 __all__ = [
     "Module",
     "Linear",
+    "Parameter",
     "ReLU",
     "Softmax",
 ]

--- a/microtorch/nn/modules/linear.py
+++ b/microtorch/nn/modules/linear.py
@@ -1,5 +1,6 @@
 import numpy as np
 
+from microtorch.nn.modules.parameter import Parameter
 from microtorch.tensor import Tensor
 
 from .module import Module
@@ -16,11 +17,11 @@ class Linear(Module[Tensor]):
 
     def __init__(self, in_features: int, out_features: int):
         super().__init__()
-        self.weight = Tensor(
+        self.weight = Parameter(
             np.random.randn(in_features, out_features),
             requires_grad=True,
         )
-        self.bias = Tensor(
+        self.bias = Parameter(
             np.zeros(out_features),
             requires_grad=True,
         )

--- a/microtorch/nn/modules/module.py
+++ b/microtorch/nn/modules/module.py
@@ -1,7 +1,9 @@
-# 3rd party imports
+# Python imports
+from collections.abc import Iterable
 from typing import Any
 
 # Local imports
+from microtorch.nn.modules.parameter import Parameter
 
 
 class Module[T]:
@@ -11,6 +13,7 @@ class Module[T]:
 
     def __init__(self):
         self._modules: dict[str, Module[Any]] = {}
+        self._parameters: dict[str, Parameter] = {}
 
     def add_module(self, name: str, module: "Module[T]"):
         self._modules[name] = module
@@ -18,6 +21,8 @@ class Module[T]:
     def __setattr__(self, name: str, value: Any):
         if isinstance(value, Module):
             self.add_module(name, value)  # type: ignore
+        elif isinstance(value, Parameter):
+            self.register_parameter(name, value)
         super().__setattr__(name, value)
 
     def __call__(self, *args: Any, **kwargs: Any):
@@ -25,3 +30,44 @@ class Module[T]:
 
     def forward(self, *args: Any, **kwargs: Any) -> T:
         raise NotImplementedError
+
+    def register_parameter(self, name: str, param: Parameter):
+        # TODO Disabling this for now because it is not possible to construct a
+        # non-leaf tensor. Consider re-enabling this check in the future.
+        # if param._backward is not None:  # type: ignore
+        #     raise ValueError(f"Cannot assign non-leaf Tensor as parameter '{name}'.")
+        self._parameters[name] = param
+
+    def named_parameters(
+        self,
+        recurse: bool = True,
+        remove_duplicate: bool = True,
+    ) -> Iterable[tuple[str, Parameter]]:
+        # memo: set[Parameter] = set()
+
+        for name, param in self._parameters.items():
+            # TODO - Re-enable this in the future and add tests for it.
+            # if remove_duplicate:
+            #     if param in memo:
+            #         continue
+            #     memo.add(param)
+            yield name, param
+        if recurse:
+            for name, module in self._modules.items():
+                for param_name, param in module.named_parameters(
+                    recurse, remove_duplicate
+                ):
+                    # TODO - Re-enable this in the future and add tests for it.
+                    # if remove_duplicate:
+                    #     if param in memo:
+                    #         continue
+                    #     memo.add(param)
+                    yield f"{name}.{param_name}", param
+
+    def parameters(
+        self,
+        recurse: bool = True,
+        remove_duplicate: bool = True,
+    ) -> Iterable[Parameter]:
+        for _, param in self.named_parameters(recurse, remove_duplicate):
+            yield param

--- a/microtorch/nn/modules/parameter.py
+++ b/microtorch/nn/modules/parameter.py
@@ -1,0 +1,9 @@
+from microtorch.tensor import Tensor
+
+
+class Parameter(Tensor):
+    """
+    A kind of Tensor that is to be considered a module parameter.
+    """
+
+    pass

--- a/tests/nn/modules/test_get_parameters.py
+++ b/tests/nn/modules/test_get_parameters.py
@@ -1,0 +1,37 @@
+from microtorch.nn.modules.activation import ReLU, Softmax
+from microtorch.nn.modules.linear import Linear
+from microtorch.nn.modules.module import Module
+from microtorch.tensor.tensor import Tensor
+
+
+def test_get_parameters_with_mnist_model():
+    class Model(Module[Tensor]):
+        def __init__(self):
+            super().__init__()
+            self.linear1 = Linear(784, 128)
+            self.relu = ReLU()
+            self.linear2 = Linear(128, 10)
+            self.softmax = Softmax(dim=-1)
+
+        def forward(self, x: Tensor) -> Tensor:
+            x = self.linear1(x)
+            x = self.relu(x)
+            x = self.linear2(x)
+            x = self.softmax(x)
+            return x
+
+    model = Model()
+    parameters = list(model.named_parameters())
+    assert len(parameters) == 4
+    assert all(isinstance(param, Tensor) for _, param in parameters)
+    assert all(param.requires_grad for _, param in parameters)
+
+    params_dict = {name: param for name, param in parameters}
+    assert "linear1.weight" in params_dict
+    assert "linear1.bias" in params_dict
+    assert "linear2.weight" in params_dict
+    assert "linear2.bias" in params_dict
+    assert params_dict["linear1.weight"].shape == (784, 128)
+    assert params_dict["linear1.bias"].shape == (128,)
+    assert params_dict["linear2.weight"].shape == (128, 10)
+    assert params_dict["linear2.bias"].shape == (10,)


### PR DESCRIPTION
As a prerequisite to implementing optimizers, we need to enable models to have parameters that should be adjusted during the back propagation process.

This close #11.